### PR TITLE
Add centos5 rpm dist macros

### DIFF
--- a/centos-5/Dockerfile
+++ b/centos-5/Dockerfile
@@ -1,4 +1,10 @@
 FROM astj/centos5-vault
 
+# centos5 doesn't have proper rpm macros defined for easily determining the
+# distibution when creating rpms. These macros can be referenced from the SPEC
+# file. The macro definitions here will bring it more inline with centos6+
+# behavior when creating rpms. 
+COPY macros.dist /etc/rpm/
+
 RUN yum install gcc make rpm-build java-1.7.0-openjdk-devel yum-utils sudo epel-release -y && \
 	yum install git -y

--- a/centos-5/macros.dist
+++ b/centos-5/macros.dist
@@ -1,0 +1,7 @@
+# dist macros.
+
+%rhel 5
+%centos 5
+%centos_ver 5
+%dist .el5
+%el5 1


### PR DESCRIPTION
Prior to this change, the %{dist} macro could not be used in a spec file
built on centos5 when it could on centos6+. This changeset adds the
missing macro defs to the rpm build env so that the same spec file that
uses macros like %{dist} can be built on centos5 - centos7.