### PR TITLE
Fix "no tty sudo" error on centos-5

### DIFF
--- a/centos-5/Dockerfile
+++ b/centos-5/Dockerfile
@@ -1,10 +1,18 @@
 FROM astj/centos5-vault
 
+RUN yum install gcc make rpm-build java-1.7.0-openjdk-devel yum-utils sudo epel-release -y && \
+	yum install git -y
+
 # centos5 doesn't have proper rpm macros defined for easily determining the
 # distibution when creating rpms. These macros can be referenced from the SPEC
 # file. The macro definitions here will bring it more inline with centos6+
 # behavior when creating rpms. 
 COPY macros.dist /etc/rpm/
 
-RUN yum install gcc make rpm-build java-1.7.0-openjdk-devel yum-utils sudo epel-release -y && \
-	yum install git -y
+# centos5 has an annoying option of sudoers enabled that affects running sudo
+# form an instance without a tty.
+# See https://bugzilla.redhat.com/show_bug.cgi?id=1020147#c9
+RUN echo -e "\n\n#includedir /etc/sudoers.d" >> /etc/sudoers
+RUN mkdir -p /etc/sudoers.d
+COPY fix_require_tty /etc/sudoers.d/
+RUN chmod 440 /etc/sudoers.d/fix_require_tty

--- a/centos-5/fix_require_tty
+++ b/centos-5/fix_require_tty
@@ -1,0 +1,1 @@
+Defaults    !requiretty


### PR DESCRIPTION
Prior to this change, if one attempted to run sudo from a shell without
a tty, the redhat-version of sudo would complain with:
    sudo: sorry, you must have a tty to run sudo
This would occur if one was running sudo from a ssh-remote-command or
automated docker instance in a build pipeline.

It is discussed in
https://bugzilla.redhat.com/show_bug.cgi?id=1020147#c9 and the sudoers
optioon that enabled it was decided to be wrong and should be disabled.
Unfortunantely, that fix was never backported to centos5 as it was
likely EOL during this decision.

This change disables the 'requiretty' option in the sudoers file.