### PR TITLE
fix bug where apt can't pull from an https source.

### DIFF
--- a/ubuntu-14/Dockerfile
+++ b/ubuntu-14/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:14.04
 
 RUN apt-get update && \
-    apt-get install gcc make openjdk-7-jdk-headless python python-pip build-essential debhelper autotools-dev autoconf automake libtool git lsb-release devscripts equivs -y && \
+    apt-get install gcc make openjdk-7-jdk-headless python python-pip \
+        build-essential debhelper autotools-dev autoconf automake libtool git \
+        lsb-release devscripts equivs apt-transport-https -y && \
     pip install boto3

--- a/ubuntu-16/Dockerfile
+++ b/ubuntu-16/Dockerfile
@@ -1,4 +1,7 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install gcc make openjdk-8-jdk-headless python python-pip build-essential debhelper autotools-dev autoconf automake libtool git lsb-release devscripts equivs sudo -y && \
+RUN apt-get update && \
+    apt-get install gcc make openjdk-8-jdk-headless python python-pip \
+        build-essential debhelper autotools-dev autoconf automake libtool git \
+        lsb-release devscripts equivs sudo apt-transport-https -y && \
     pip install boto3


### PR DESCRIPTION
This change set adds the ability for apt-get to pull from https sources
by installing the apt-https-transport package