### PR TITLE
[CONTRAST-26269] Install Ruby 2.5.1 on Centos-7, Ubuntu 14/16/18 images.

### DIFF
--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:7
 
 RUN yum install -y gcc make rpm-build java-1.8.0-openjdk-devel epel-release && \
-    yum install -y python-pip git yum-utils sudo && \
-    pip install boto3
+    yum install -y python-pip git yum-utils sudo which libcurl libcurl-devel curl && \
+    pip install boto3 && curl -sSL https://rvm.io/mpapis.asc | gpg --import - && curl -sSL https://get.rvm.io | bash -s stable --ruby

--- a/ubuntu-14/Dockerfile
+++ b/ubuntu-14/Dockerfile
@@ -4,4 +4,4 @@ RUN apt-get update && \
     apt-get install gcc make openjdk-7-jdk-headless python python-pip \
         build-essential debhelper autotools-dev autoconf automake libtool git \
         lsb-release devscripts equivs apt-transport-https -y && \
-    pip install boto3
+    pip install boto3 && curl -sSL https://rvm.io/mpapis.asc | gpg --import - && curl -sSL https://get.rvm.io | bash -s stable --ruby

--- a/ubuntu-16/Dockerfile
+++ b/ubuntu-16/Dockerfile
@@ -4,4 +4,4 @@ RUN apt-get update && \
     apt-get install gcc make openjdk-8-jdk-headless python python-pip \
         build-essential debhelper autotools-dev autoconf automake libtool git \
         lsb-release devscripts equivs sudo apt-transport-https -y && \
-    pip install boto3
+    pip install boto3 && curl -sSL https://rvm.io/mpapis.asc | gpg --import - && curl -sSL https://get.rvm.io | bash -s stable --ruby

--- a/ubuntu-18/Dockerfile
+++ b/ubuntu-18/Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install gcc make openjdk-8-jdk-headless python python-pip build-essential debhelper autotools-dev autoconf automake libtool git lsb-release devscripts equivs sudo -y && \
+RUN apt-get update && apt-get install gcc make openjdk-8-jdk-headless python python-pip build-essential debhelper autotools-dev autoconf automake libtool git lsb-release devscripts equivs sudo ruby-curb ruby-dev -y && \
     pip install boto3


### PR DESCRIPTION
DARPA uses centos-7, and ubuntu 14/16/18 installer images during integration test for the WAF agent.  

Most of our testing time is spent installing ruby on the images. To speed this up, we install ruby on the base images beforehand. 